### PR TITLE
Link to options, fix manifest warning, put back package-lock.json hasInstallScript

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,6 @@
     "webRequest"
   ],
   "host_permissions": ["*://*/*"],
-  "optional_host_permissions": ["*://*/*"],
   "options_ui": {
     "page": "options.html",
     "browser_style": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "redwood",
   "version": "1.0.0",
-  "hasInstallScript": true,
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "redwood",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@via-ds/tokens": "^0.0.1-canary.0"

--- a/popup.html
+++ b/popup.html
@@ -8,7 +8,10 @@
 </head>
 <body class="p-0">
     <div class="bg-dark-background-primary font-body">
-        <h1 class="js-heading m-0 px-300 py-200 text-heading4 font-semibold text-dark-text-primary bg-gray-dark2 data-[active]:bg-dark-background-success" data-active>▶️ Redwood is running</h1>
+        <div class="flex items-center bg-gray-dark2" id="header-container">
+            <h1 class="js-heading m-0 px-300 py-200 text-heading4 font-semibold text-dark-text-primary" style="flex: 1;" data-active>▶️ Redwood is running</h1>
+            <button id="settings-button" class="px-300 py-200 cursor-pointer text-dark-text-primary" title="Settings">⚙️</button>
+        </div>
         <main class="p-300 min-w-[300px]">
             <div class="popup-row">
                 <span class="popup-label">Enable</span>

--- a/popup.js
+++ b/popup.js
@@ -137,14 +137,27 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('toggle-switch').addEventListener('change', (e) => {
         chrome.storage.sync.set({ isActive: e.target.checked });
     });
+
+    document.getElementById('settings-button').addEventListener('click', () => {
+        chrome.runtime.openOptionsPage();
+    });
 });
 
 function applyActiveState(isActive) {
     const heading = document.querySelector('.js-heading');
     const toggle = document.getElementById('toggle-switch');
+    const headerContainer = document.getElementById('header-container');
 
     heading.toggleAttribute('data-active', isActive);
     heading.textContent = isActive ? '▶️ Redwood is running' : '⏹️ Redwood is paused';
+
+    if (isActive) {
+        headerContainer.classList.remove('bg-gray-dark2');
+        headerContainer.classList.add('bg-green-dark2');
+    } else {
+        headerContainer.classList.remove('bg-green-dark2');
+        headerContainer.classList.add('bg-gray-dark2');
+    }
 
     toggle.checked = isActive;
 }


### PR DESCRIPTION
- Added a gear button that leads to options 
<img width="418" height="233" alt="image" src="https://github.com/user-attachments/assets/be317025-aa9b-491a-b14c-d1fb73880ea3" />

- Removed some permission in manifest as it was called redundant in the extensions page
- Reverted an accidental change to package-lock.json from a previous commit